### PR TITLE
Refactor rental pricing and add full test coverage

### DIFF
--- a/form.html
+++ b/form.html
@@ -98,8 +98,13 @@
             </select>
 
             <div class="form-group">
-                <label for="age">Diver's age</label>
-                <input type="number" class="form-control" name="age" required/>
+                <label for="age">Driver's age</label>
+                <input type="number" class="form-control" id="age" name="age" min="18" required>
+            </div>
+
+            <div class="form-group">
+                <label for="license-years">Years with driver's license</label>
+                <input type="number" class="form-control" id="license-years" name="licenseYears" min="0" step="1" required>
             </div>
 
             <button type="submit" class="btn btn-primary">Search</button>

--- a/index.js
+++ b/index.js
@@ -1,37 +1,41 @@
-const express = require('express');
-const bodyParser = require('body-parser');
-const rental = require('./rentalPrice');
-const fs = require('fs');
+const bodyParser = require("body-parser");
+const express = require("express");
+const fs = require("fs");
+
+const rental = require("./rentalPrice");
 
 const app = express();
 const port = 3000;
 
 app.use(bodyParser.urlencoded({ extended: true }));
 
-app.use(express.static('public'));
-app.use('/pictures', express.static('images'));
+app.use(express.static("public"));
+app.use("/pictures", express.static("images"));
 
-const formHtml = fs.readFileSync('form.html', 'utf8');
-const resultHtml = fs.readFileSync('result.html', 'utf8');
+const formHtml = fs.readFileSync("form.html", "utf8");
+const resultHtml = fs.readFileSync("result.html", "utf8");
 
-app.post('/', (req, res) => {
-    const post = req.body;
-    const result = rental.price(
-        String(post.pickup),
-        String(post.dropoff),
-        Date.parse(post.pickupdate),
-        Date.parse(post.dropoffdate),
-        String(post.type),
-        Number(post.age)
-    );
-    res.send(formHtml + resultHtml.replaceAll('$0', result));
+app.post("/", (req, res) => {
+  const post = req.body;
+  const result = rental.price(
+    String(post.pickup),
+    String(post.dropoff),
+    Date.parse(post.pickupdate),
+    Date.parse(post.dropoffdate),
+    String(post.type),
+    Number(post.age),
+    Number(post.licenseYears)
+  );
+
+  res.send(formHtml + resultHtml.replaceAll("$0", result));
 });
 
-app.get('/', (req, res) => {
-    res.send(formHtml);
+app.get("/", (req, res) => {
+  res.send(formHtml);
 });
 
 // Start the server
 app.listen(port, () => {
-    console.log(`Server listening at http://localhost:${port}`);
+  // eslint-disable-next-line no-console
+  console.log(`Server listening at http://localhost:${port}`);
 });

--- a/rentalPrice.js
+++ b/rentalPrice.js
@@ -157,7 +157,9 @@ function calculateRentalPrice({
   return totalPrice;
 }
 function formatPrice(amount) {
-  return `$${amount.toFixed(2)}`;
+  const formattedAmount = amount.toFixed(2).replace(/\.00$/, "");
+
+  return `$${formattedAmount}`;
 }
 
 function price(pickup, dropoff, pickupDate, dropoffDate, type, age, licenseYears = Infinity) {

--- a/rentalPrice.js
+++ b/rentalPrice.js
@@ -109,7 +109,7 @@ function validateRental(age, carClass, licenseYears) {
   }
 
   if (licenseYears < MINIMUM_LICENSE_YEARS) {
-    return "Driver must hold a license for at least 1 year";
+    return "Driver license held for less than a year - cannot rent";
   }
 
   return null;
@@ -130,10 +130,6 @@ function calculateRentalPrice({
   const weekendPrice = weekendDays * age * (1 + WEEKEND_SURCHARGE_RATE);
   let totalPrice = weekdayPrice + weekendPrice;
 
-  if (season === SEASONS.HIGH && licenseYears < HIGH_SEASON_DAILY_FEE_YEARS) {
-    totalPrice += rentalDays * HIGH_SEASON_NEW_DRIVER_DAILY_FEE;
-  }
-
   if (
     carClass === CAR_CLASSES.RACER
     && age <= RACER_SURCHARGE_AGE_LIMIT
@@ -144,6 +140,10 @@ function calculateRentalPrice({
 
   if (season === SEASONS.HIGH) {
     totalPrice *= 1 + HIGH_SEASON_SURCHARGE_RATE;
+  }
+
+  if (season === SEASONS.HIGH && licenseYears < HIGH_SEASON_DAILY_FEE_YEARS) {
+    totalPrice += rentalDays * HIGH_SEASON_NEW_DRIVER_DAILY_FEE;
   }
 
   if (season === SEASONS.LOW && rentalDays > LONG_RENTAL_DISCOUNT_DAYS) {

--- a/rentalPrice.js
+++ b/rentalPrice.js
@@ -1,75 +1,190 @@
+const CAR_CLASSES = Object.freeze({
+  COMPACT: "Compact",
+  ELECTRIC: "Electric",
+  CABRIO: "Cabrio",
+  RACER: "Racer",
+  UNKNOWN: "Unknown"
+});
 
-function price(pickup, dropoff, pickupDate, dropoffDate, type, age) {
-  const clazz = getClazz(type);
-  const days = get_days(pickupDate, dropoffDate);
-  const season = getSeason(pickupDate, dropoffDate);
+const SEASONS = Object.freeze({
+  HIGH: "High",
+  LOW: "Low"
+});
 
-  if (age < 18) {
-      return "Driver too young - cannot quote the price";
+const MINIMUM_DRIVER_AGE = 18;
+const COMPACT_ONLY_AGE_LIMIT = 21;
+const RACER_SURCHARGE_AGE_LIMIT = 25;
+const MINIMUM_LICENSE_YEARS = 1;
+const LICENSE_SURCHARGE_YEARS = 2;
+const HIGH_SEASON_DAILY_FEE_YEARS = 3;
+const LONG_RENTAL_DISCOUNT_DAYS = 10;
+const HIGH_SEASON_START_MONTH = 3;
+const HIGH_SEASON_END_MONTH = 9;
+const WEEKEND_SURCHARGE_RATE = 0.05;
+const RACER_SURCHARGE_RATE = 0.5;
+const HIGH_SEASON_SURCHARGE_RATE = 0.15;
+const LOW_SEASON_LONG_RENTAL_DISCOUNT_RATE = 0.1;
+const NEW_DRIVER_SURCHARGE_RATE = 0.3;
+const HIGH_SEASON_NEW_DRIVER_DAILY_FEE = 15;
+const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000;
+const WEEKEND_DAY_INDEXES = [0, 6];
+
+function getCarClass(type) {
+  const normalizedType = String(type).trim().toLowerCase();
+
+  switch (normalizedType) {
+  case "compact":
+    return CAR_CLASSES.COMPACT;
+  case "electric":
+    return CAR_CLASSES.ELECTRIC;
+  case "cabrio":
+    return CAR_CLASSES.CABRIO;
+  case "racer":
+    return CAR_CLASSES.RACER;
+  default:
+    return CAR_CLASSES.UNKNOWN;
   }
-
-  if (age <= 21 && clazz !== "Compact") {
-      return "Drivers 21 y/o or less can only rent Compact vehicles";
-  }
-
-  let rentalprice = age * days;
-
-  if (clazz === "Racer" && age <= 25 && season === "High") {
-      rentalprice *= 1.5;
-  }
-
-  if (season === "High" ) {
-    rentalprice *= 1.15;
-  }
-
-  if (days > 10 && season === "Low" ) {
-      rentalprice *= 0.9;
-  }
-  return '$' + rentalprice;
 }
 
-function getClazz(type) {
-  switch (type) {
-      case "Compact":
-          return "Compact";
-      case "Electric":
-          return "Electric";
-      case "Cabrio":
-          return "Cabrio";
-      case "Racer":
-          return "Racer";
-      default:
-          return "Unknown";
-  }
-}
-
-function get_days(pickupDate, dropoffDate) {
-  const oneDay = 24 * 60 * 60 * 1000; // hours*minutes*seconds*milliseconds
+function getOrderedDates(pickupDate, dropoffDate) {
   const firstDate = new Date(pickupDate);
   const secondDate = new Date(dropoffDate);
 
-  return Math.round(Math.abs((firstDate - secondDate) / oneDay)) + 1;
+  if (firstDate <= secondDate) {
+    return { startDate: firstDate, endDate: secondDate };
+  }
+
+  return { startDate: secondDate, endDate: firstDate };
+}
+
+function isHighSeasonMonth(month) {
+  return month >= HIGH_SEASON_START_MONTH && month <= HIGH_SEASON_END_MONTH;
+}
+
+function getRentalDays(pickupDate, dropoffDate) {
+  const { startDate, endDate } = getOrderedDates(pickupDate, dropoffDate);
+  const differenceInDays = Math.round((endDate - startDate) / MILLISECONDS_IN_DAY);
+
+  return differenceInDays + 1;
 }
 
 function getSeason(pickupDate, dropoffDate) {
-  const pickup = new Date(pickupDate);
-  const dropoff = new Date(dropoffDate);
+  const { startDate, endDate } = getOrderedDates(pickupDate, dropoffDate);
+  const currentDate = new Date(startDate);
 
-  const start = 4; 
-  const end = 10;
+  while (currentDate <= endDate) {
+    if (isHighSeasonMonth(currentDate.getMonth())) {
+      return SEASONS.HIGH;
+    }
 
-  const pickupMonth = pickup.getMonth();
-  const dropoffMonth = dropoff.getMonth();
-
-  if (
-      (pickupMonth >= start && pickupMonth <= end) ||
-      (dropoffMonth >= start && dropoffMonth <= end) ||
-      (pickupMonth < start && dropoffMonth > end)
-  ) {
-      return "High";
-  } else {
-      return "Low";
+    currentDate.setDate(currentDate.getDate() + 1);
   }
+
+  return SEASONS.LOW;
 }
 
-exports.price = price;
+function countWeekendDays(pickupDate, dropoffDate) {
+  const { startDate, endDate } = getOrderedDates(pickupDate, dropoffDate);
+  const currentDate = new Date(startDate);
+  let weekendDays = 0;
+
+  while (currentDate <= endDate) {
+    if (WEEKEND_DAY_INDEXES.includes(currentDate.getDay())) {
+      weekendDays += 1;
+    }
+
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  return weekendDays;
+}
+
+function validateRental(age, carClass, licenseYears) {
+  if (age < MINIMUM_DRIVER_AGE) {
+    return "Driver too young - cannot quote the price";
+  }
+
+  if (age <= COMPACT_ONLY_AGE_LIMIT && carClass !== CAR_CLASSES.COMPACT) {
+    return "Drivers 21 y/o or less can only rent Compact vehicles";
+  }
+
+  if (licenseYears < MINIMUM_LICENSE_YEARS) {
+    return "Driver must hold a license for at least 1 year";
+  }
+
+  return null;
+}
+
+function calculateRentalPrice({
+  pickupDate,
+  dropoffDate,
+  age,
+  licenseYears,
+  carClass,
+  rentalDays,
+  season
+}) {
+  const weekendDays = countWeekendDays(pickupDate, dropoffDate);
+  const weekdayDays = rentalDays - weekendDays;
+  const weekdayPrice = weekdayDays * age;
+  const weekendPrice = weekendDays * age * (1 + WEEKEND_SURCHARGE_RATE);
+  let totalPrice = weekdayPrice + weekendPrice;
+
+  if (season === SEASONS.HIGH && licenseYears < HIGH_SEASON_DAILY_FEE_YEARS) {
+    totalPrice += rentalDays * HIGH_SEASON_NEW_DRIVER_DAILY_FEE;
+  }
+
+  if (
+    carClass === CAR_CLASSES.RACER
+    && age <= RACER_SURCHARGE_AGE_LIMIT
+    && season === SEASONS.HIGH
+  ) {
+    totalPrice *= 1 + RACER_SURCHARGE_RATE;
+  }
+
+  if (season === SEASONS.HIGH) {
+    totalPrice *= 1 + HIGH_SEASON_SURCHARGE_RATE;
+  }
+
+  if (season === SEASONS.LOW && rentalDays > LONG_RENTAL_DISCOUNT_DAYS) {
+    totalPrice *= 1 - LOW_SEASON_LONG_RENTAL_DISCOUNT_RATE;
+  }
+
+  if (licenseYears < LICENSE_SURCHARGE_YEARS) {
+    totalPrice *= 1 + NEW_DRIVER_SURCHARGE_RATE;
+  }
+
+  return totalPrice;
+}
+function formatPrice(amount) {
+  return `$${amount.toFixed(2)}`;
+}
+
+function price(pickup, dropoff, pickupDate, dropoffDate, type, age, licenseYears = Infinity) {
+  const carClass = getCarClass(type);
+  const rentalDays = getRentalDays(pickupDate, dropoffDate);
+  const season = getSeason(pickupDate, dropoffDate);
+  const validationError = validateRental(age, carClass, licenseYears);
+
+  if (validationError) {
+    return validationError;
+  }
+
+  return formatPrice(calculateRentalPrice({
+    pickupDate,
+    dropoffDate,
+    age,
+    licenseYears,
+    carClass,
+    rentalDays,
+    season
+  }));
+}
+
+module.exports = {
+  price,
+  getCarClass,
+  getRentalDays,
+  getSeason,
+  countWeekendDays
+};

--- a/rentalPrice.test.js
+++ b/rentalPrice.test.js
@@ -1,0 +1,220 @@
+const {
+  price,
+  getCarClass,
+  getRentalDays,
+  getSeason,
+  countWeekendDays
+} = require("./rentalPrice");
+
+describe("getCarClass", () => {
+  test("returns known car class names", () => {
+    expect(getCarClass("Compact")).toBe("Compact");
+    expect(getCarClass("Electric")).toBe("Electric");
+    expect(getCarClass("Cabrio")).toBe("Cabrio");
+    expect(getCarClass("Racer")).toBe("Racer");
+  });
+
+  test("returns Unknown for unsupported car types", () => {
+    expect(getCarClass("Truck")).toBe("Unknown");
+  });
+});
+
+describe("getRentalDays", () => {
+  test("counts rental days inclusively", () => {
+    const pickupDate = Date.parse("2026-04-13");
+    const dropoffDate = Date.parse("2026-04-15");
+
+    expect(getRentalDays(pickupDate, dropoffDate)).toBe(3);
+  });
+
+  test("handles dates that are passed in reverse order", () => {
+    const pickupDate = Date.parse("2026-04-15");
+    const dropoffDate = Date.parse("2026-04-13");
+
+    expect(getRentalDays(pickupDate, dropoffDate)).toBe(3);
+  });
+
+  test("returns one day for same-day rentals", () => {
+    const pickupDate = Date.parse("2026-04-13");
+    const dropoffDate = Date.parse("2026-04-13");
+
+    expect(getRentalDays(pickupDate, dropoffDate)).toBe(1);
+  });
+});
+
+describe("getSeason", () => {
+  test("returns High for dates inside the high season", () => {
+    expect(
+      getSeason(Date.parse("2026-07-01"), Date.parse("2026-07-03"))
+    ).toBe("High");
+  });
+
+  test("returns High when rental crosses from low to high season", () => {
+    expect(
+      getSeason(Date.parse("2026-03-30"), Date.parse("2026-04-02"))
+    ).toBe("High");
+  });
+
+  test("returns Low for dates fully inside the low season", () => {
+    expect(
+      getSeason(Date.parse("2026-11-10"), Date.parse("2026-11-12"))
+    ).toBe("Low");
+  });
+});
+
+describe("countWeekendDays", () => {
+  test("counts Saturday and Sunday inside the rental period", () => {
+    const pickupDate = Date.parse("2026-04-16");
+    const dropoffDate = Date.parse("2026-04-20");
+
+    expect(countWeekendDays(pickupDate, dropoffDate)).toBe(2);
+  });
+
+  test("returns zero when the rental period has no weekend days", () => {
+    const pickupDate = Date.parse("2026-04-13");
+    const dropoffDate = Date.parse("2026-04-15");
+
+    expect(countWeekendDays(pickupDate, dropoffDate)).toBe(0);
+  });
+});
+
+describe("price", () => {
+  test("rejects drivers younger than 18", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-04-13"),
+      Date.parse("2026-04-13"),
+      "Compact",
+      17,
+      5
+    );
+
+    expect(result).toBe("Driver too young - cannot quote the price");
+  });
+
+  test("rejects young drivers who request a non-compact car", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-04-13"),
+      Date.parse("2026-04-13"),
+      "Electric",
+      21,
+      5
+    );
+
+    expect(result).toBe("Drivers 21 y/o or less can only rent Compact vehicles");
+  });
+
+  test("rejects drivers who have held a license for less than one year", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-04-13"),
+      Date.parse("2026-04-13"),
+      "Compact",
+      30,
+      0
+    );
+
+    expect(result).toBe("Driver must hold a license for at least 1 year");
+  });
+
+  test("adds 30 percent when the license is younger than two years", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-11-10"),
+      Date.parse("2026-11-10"),
+      "Compact",
+      30,
+      1
+    );
+
+    expect(result).toBe("$39.00");
+  });
+
+  test("adds 15 euros per day in high season when the license is younger than three years", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-07-01"),
+      Date.parse("2026-07-03"),
+      "Compact",
+      30,
+      2
+    );
+
+    expect(result).toBe("$155.25");
+  });
+
+  test("adds the racer surcharge only in high season for drivers aged 25 or less", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-07-01"),
+      Date.parse("2026-07-03"),
+      "Racer",
+      25,
+      5
+    );
+
+    expect(result).toBe("$129.38");
+  });
+
+  test("applies a low-season discount for rentals longer than 10 days", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-11-01"),
+      Date.parse("2026-11-11"),
+      "Compact",
+      40,
+      5
+    );
+
+    expect(result).toBe("$401.40");
+  });
+
+  test("keeps weekday pricing unchanged in the TDD scenario", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-01-12"),
+      Date.parse("2026-01-14"),
+      "Compact",
+      50,
+      5
+    );
+
+    expect(result).toBe("$150.00");
+  });
+
+  test("increases the total when the rental includes one weekend day in the TDD scenario", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-01-15"),
+      Date.parse("2026-01-17"),
+      "Compact",
+      50,
+      5
+    );
+
+    expect(result).toBe("$152.50");
+  });
+
+  test("uses the default license years when the argument is omitted", () => {
+    const result = price(
+      "Tallinn",
+      "Tartu",
+      Date.parse("2026-01-12"),
+      Date.parse("2026-01-14"),
+      "Compact",
+      50
+    );
+
+    expect(result).toBe("$150.00");
+  });
+});

--- a/rentalPrice.test.js
+++ b/rentalPrice.test.js
@@ -132,7 +132,7 @@ describe("price", () => {
       1
     );
 
-    expect(result).toBe("$39.00");
+    expect(result).toBe("$39");
   });
 
   test("adds 15 euros per day in high season when the license is younger than three years", () => {
@@ -188,7 +188,7 @@ describe("price", () => {
       5
     );
 
-    expect(result).toBe("$150.00");
+    expect(result).toBe("$150");
   });
 
   test("increases the total when the rental includes one weekend day in the TDD scenario", () => {
@@ -215,6 +215,6 @@ describe("price", () => {
       50
     );
 
-    expect(result).toBe("$150.00");
+    expect(result).toBe("$150");
   });
 });

--- a/rentalPrice.test.js
+++ b/rentalPrice.test.js
@@ -118,7 +118,7 @@ describe("price", () => {
       0
     );
 
-    expect(result).toBe("Driver must hold a license for at least 1 year");
+    expect(result).toBe("Driver license held for less than a year - cannot rent");
   });
 
   test("adds 30 percent when the license is younger than two years", () => {
@@ -146,7 +146,7 @@ describe("price", () => {
       2
     );
 
-    expect(result).toBe("$155.25");
+    expect(result).toBe("$148.50");
   });
 
   test("adds the racer surcharge only in high season for drivers aged 25 or less", () => {


### PR DESCRIPTION
Anneli Peep 
alla 1 aasta juhiloaga rentida ei saa
alla 2 aasta juhiloaga lisandub 30% lisatasu
alla 3 aasta juhiloaga lisandub high season ajal 15 eurot päevas
lisasin TDD käigus nädalavahetuse hinnastuse:
nädalavahetuse päevadel on 5% hinnalisa
lisasin vormi uue välja juhiloa aastate jaoks
ühendasin uue välja backendi hinnaarvutusega
kirjutasin ühiktestid kõigile eksporditud funktsioonidele 

npm test -- --runInBand --coverage
tulemus: 100% line, branch, function ja statement coverage
ESLint läheb läbi ilma hoiatusteta